### PR TITLE
Clarify reference to grblas Python interface.

### DIFF
--- a/Doc/GraphBLAS_UserGuide.tex
+++ b/Doc/GraphBLAS_UserGuide.tex
@@ -938,7 +938,8 @@ GraphBLAS matrices.  Some of these may be added in future releases.
 
 See Michel Pelletier's Python interface at
 \href{https://github.com/michelp/pygraphblas}{https://github.com/michelp/pygraphblas}.
-Anaconda is also developing a Python interface to SuiteSparse:GraphBLAS.
+See Jim Kitchen and Erik Welch's (both from Anaconda, Inc.) Python interface at
+\href{https://github.com/metagraph-dev/grblas}{https://github.com/metagraph-dev/grblas}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Julia Interface} %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I just saw this reference in the user guide and thought it could be clarified.