### PR TITLE
Add macOS to aarch64 platforms

### DIFF
--- a/cpu_features/src/impl_aarch64.c
+++ b/cpu_features/src/impl_aarch64.c
@@ -15,7 +15,7 @@
 #include "cpu_features_macros.h"
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
-#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
+#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID) || defined(CPU_FEATURES_OS_MACOS)
 
 #include "cpuinfo_aarch64.h"
 
@@ -146,5 +146,5 @@ Aarch64Info GetAarch64Info(void) {
   return info;
 }
 
-#endif  // defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
+#endif  // defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID) || defined(CPU_FEATURES_OS_MACOS)
 #endif  // CPU_FEATURES_ARCH_AARCH64

--- a/cpu_features/test/CMakeLists.txt
+++ b/cpu_features/test/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 ##------------------------------------------------------------------------------
 ## cpuinfo_aarch64_test
 if(PROCESSOR_IS_AARCH64)
-  add_executable(cpuinfo_aarch64_test cpuinfo_aarch64_test.cc ../src/impl_aarch64_linux_or_android.c)
+  add_executable(cpuinfo_aarch64_test cpuinfo_aarch64_test.cc ../src/impl_aarch64.c)
   target_link_libraries(cpuinfo_aarch64_test all_libraries)
   add_test(NAME cpuinfo_aarch64_test COMMAND cpuinfo_aarch64_test)
 endif()


### PR DESCRIPTION
As I have remarked in https://github.com/DrTimothyAldenDavis/GraphBLAS/issues/41#issuecomment-1002676478, v6.1.1 works in Rosetta.

Without Rosetta, `make` fails with the following error with both Clang and GCC:

```
$ make
...
[100%] Linking C executable list_cpu_features
Undefined symbols for architecture arm64:
  "_GetAarch64FeaturesEnumName", referenced from:
      _main in list_cpu_features.c.o
  "_GetAarch64FeaturesEnumValue", referenced from:
      _main in list_cpu_features.c.o
  "_GetAarch64Info", referenced from:
      _main in list_cpu_features.c.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The solution is to apply the workaround suggested at https://github.com/google/cpu_features/pull/211.
This PR makes this change.