### PR TITLE
Minor fixes in testing (README and gbmake script)

### DIFF
--- a/GraphBLAS/@GrB/private/gbmake.m
+++ b/GraphBLAS/@GrB/private/gbmake.m
@@ -27,7 +27,7 @@ need_rename = false ;
 
 if (have_octave)
     if verLessThan ('octave', '7')
-        gb_error ('Octave 7 or later is required') ;
+        error ('Octave 7 or later is required') ;
     end
 else
     if verLessThan ('matlab', '9.4')

--- a/GraphBLAS/README.md
+++ b/GraphBLAS/README.md
@@ -9,7 +9,7 @@ You may not use the @GrB interface under the Apache-2.0 license.
 The @GrB class provides an easy-to-use interface to SuiteSparse:GraphBLAS.
 
 To install it for use in Octave/MATLAB, first compile the GraphBLAS library,
--lgraphblas (or -lgraphblas_rename for MATLAB R2021a and later).  See the
+-lgraphblas (or -lgraphblas_renamed for MATLAB R2021a and later).  See the
 instructions in the top-level GraphBLAS folder for details.  Be sure to use
 OpenMP for best performance.  The default installation process places the
 GraphBLAS library in /usr/local/lib.  If you do not have root access and cannot
@@ -19,9 +19,9 @@ modify your library path, but instead of /usr/local/lib, use
 where you placed your copy of GraphBLAS.
 
 If you have MATLAB R2021a, the gbmake script will link against the library
--lgraphblas_rename, not -lgraphblas, because that version of MATLAB includes
+-lgraphblas_renamed, not -lgraphblas, because that version of MATLAB includes
 its own version of SuiteSparse:GraphBLAS (v3.3.3, an earlier one).  To avoid a
-name conflict, you must compile the -lgraphblas_rename library in
+name conflict, you must compile the -lgraphblas_renamed library in
 /home/me/SuiteSparse/GraphBLAS/GraphBLAS/build.
 
 Octave/MATLAB needs to know where to find the compiled GraphBLAS library.  On
@@ -45,7 +45,7 @@ If you don't have system priveledges to change /usr/local/lib, then add the
 build folder to your LD_LIBRARY_PATH instead, either.  For Octave, and MATLAB
 R2020b and earlier: /home/me/SuiteSparse/GraphBLAS/build for libgraphblas.so,
 For R2021a:  /home/me/SuiteSparse/GraphBLAS/GraphBLAS/build for
-libgraphblas_rename.so.
+libgraphblas_renamed.so.
 
 On Windows 10, on the Search bar type env and hit enter; (or you can
 right-click My Computer or This PC and select Properties, and then select
@@ -54,7 +54,7 @@ then "Environment Variables".  Under "System Variables" select "Path" and click
 "Edit".  These "New" to add a path and then "Browse".  Browse to the folder
 (for example: C:/Users/me/Documents/SuiteSparse/GraphBLAS/build/Release) and
 add it to your path.  For MATLAB R2021a and later, you must use the
-libgraphblas_rename.dll, in:
+libgraphblas_renamed.dll, in:
 /User/me/SuiteSparse/GraphBLAS/GraphBLAS/build/Release instead.  Then close the
 editor, sign out of Windows and sign back in again.
 

--- a/GraphBLAS/README.md
+++ b/GraphBLAS/README.md
@@ -78,7 +78,7 @@ this folder.
 The name "GraphBLAS/GraphBLAS" is used for this folder so that this can be done
 in Octave/MATLAB:
 
-    help graphblas
+    help GraphBLAS
 
 To get additional help, type:
 


### PR DESCRIPTION
This PR makes a few minor fixes in the testing README and codebase:
* Tests in MATLAB should use the `graphblas_renamed` library
* The `gb_error` call (which causes the build to fail for me) was changed to `error`
* I fixed capitalization: `help graphblas` did not work but `help GraphBLAS` does
