### PR TITLE
check for pending operations

### DIFF
--- a/Config/GraphBLAS.h.in
+++ b/Config/GraphBLAS.h.in
@@ -9623,6 +9623,16 @@ GrB_Info GxB_Vector_resize      // change the size of a vector (historical)
     (arg1, __VA_ARGS__)
 #endif
 
+//------------------------------------------------------------------------------
+// GxB_Matrix_pending:  Checks to see if matrix has pending operations
+//------------------------------------------------------------------------------
+
+GrB_Info GxB_Matrix_pending
+(
+	GrB_Matrix A,                   // matrix to query
+	bool *pending                   // are there any pending operations
+) ;
+
 //==============================================================================
 // GxB_fprint and GxB_print: print the contents of a GraphBLAS object
 //==============================================================================

--- a/Include/GraphBLAS.h
+++ b/Include/GraphBLAS.h
@@ -9623,6 +9623,16 @@ GrB_Info GxB_Vector_resize      // change the size of a vector (historical)
     (arg1, __VA_ARGS__)
 #endif
 
+//------------------------------------------------------------------------------
+// GxB_Matrix_pending:  Checks to see if matrix has pending operations
+//------------------------------------------------------------------------------
+
+GrB_Info GxB_Matrix_pending
+(
+	GrB_Matrix A,                   // matrix to query
+	bool *pending                   // are there any pending operations
+) ;
+
 //==============================================================================
 // GxB_fprint and GxB_print: print the contents of a GraphBLAS object
 //==============================================================================

--- a/Source/GxB_Matrix_pending.c
+++ b/Source/GxB_Matrix_pending.c
@@ -1,0 +1,24 @@
+//------------------------------------------------------------------------------
+// GxB_Matrix_Pending: checks to see if matrix has pending operations
+//------------------------------------------------------------------------------
+
+#include "GB.h"
+#include "GB_Pending.h"
+
+GrB_Info GxB_Matrix_pending     // does matrix has pending operations
+(
+	GrB_Matrix A,           // matrix to query
+	bool *pending           // are there any pending operations
+) {
+	GB_WHERE1 ("GxB_Matrix_Pending (A)") ;
+	//--------------------------------------------------------------------------
+	// check inputs
+	//--------------------------------------------------------------------------
+	GB_RETURN_IF_NULL_OR_FAULTY(A) ;
+	GB_RETURN_IF_NULL(pending) ;
+
+	(*pending) = (GB_ANY_PENDING_WORK (A) || GB_NEED_HYPER_HASH (A)) ;
+
+	return (GrB_SUCCESS) ;
+}
+


### PR DESCRIPTION
This pull-request adds the `GxB_Matrix_pending` function which checks if a matrix `A` has any pending work:

1. pending tuples
2. zombies
3. jumbled
4. hyper-hash

In which case the functions sets its input/output argument to true otherwise the argument is set to false.
Please let me know if I should add a test.