### PR TITLE
Move detection of MinGW out of compiler condition chain.

### DIFF
--- a/Source/GB_compiler.h
+++ b/Source/GB_compiler.h
@@ -78,22 +78,6 @@
     #define GB_COMPILER_SUB   0
     #define GB_COMPILER_NAME  "IBM xlc " GB_XSTR (__xlC__)
 
-#elif defined ( __MINGW32__ ) || defined ( __MINGW64__ )
-
-    // MinGW (32-bit or 64-bit)
-    #undef  GB_COMPILER_MINGW
-    #define GB_COMPILER_MINGW   1
-
-    #if defined ( __MINGW32__ )
-    #define GB_COMPILER_MAJOR ( __MINGW32_MAJOR_VERSION )
-    #define GB_COMPILER_MINOR ( __MINGW32_MINOR_VERSION )
-    #else
-    #define GB_COMPILER_MAJOR ( __MINGW64_MAJOR_VERSION )
-    #define GB_COMPILER_MINOR ( __MINGW64_MINOR_VERSION )
-    #endif
-    #define GB_COMPILER_SUB   0
-    #define GB_COMPILER_NAME  "MinGW"
-
 #elif defined ( __GNUC__ )
 
     // gcc
@@ -126,6 +110,15 @@
     #define GB_COMPILER_NAME  "other C compiler"
 
 #endif
+
+// MinGW is not a compiler. But a variable with this name is used
+// in different places.
+#if defined ( __MINGW32__ )
+    // MinGW (32-bit or 64-bit)
+    #undef  GB_COMPILER_MINGW
+    #define GB_COMPILER_MINGW   1
+#endif
+
 
 //------------------------------------------------------------------------------
 // Workaround for compiler bug in Microsoft Visual Studio 2019


### PR DESCRIPTION
MinGW is not a compiler. Different compilers can be used with MinGW.

Move the detection of MinGW out of the compiler detection chain into a separate test.

Fixes #181.