### PR TITLE
Disable cpu_features for all compilers on Windows.

### DIFF
--- a/Source/GB_cpu_features.h
+++ b/Source/GB_cpu_features.h
@@ -59,7 +59,7 @@
 // rely on Google's cpu_features package for run-time tests
 //------------------------------------------------------------------------------
 
-#if GB_COMPILER_MSC || GB_COMPILER_NVCC || GB_MINGW
+#if defined (_WIN32) || GB_COMPILER_NVCC
 // entirely disable cpu_features for MS Visual Studio, nvcc, and MinGW
 #undef  GBNCPUFEAT
 #define GBNCPUFEAT 1


### PR DESCRIPTION
When trying to build GraphBLAS with Intel icx on Windows, compilation fails while building cpu_features.
Compilation presumably works with this compiler on Linux. (But I haven't actually tested.)

Instead of listing a series of compilers, deactivate cpu_features on Windows with any compiler.

I don't know what nvcc is. So, I left that part of the condition alone.