### PR TITLE
Use same type for complex arguments in library and downstream.

### DIFF
--- a/Config/GraphBLAS.h.in
+++ b/Config/GraphBLAS.h.in
@@ -135,28 +135,10 @@
 // This is a copy of GraphBLAS/Source/Shared/GxB_complex.h.  It is included
 // here as a full copy so that the GraphBLAS.h file can be self contained.
 
-// See:
-// https://www.drdobbs.com/complex-arithmetic-in-the-intersection-o/184401628#
-
 #ifndef GXB_COMPLEX_H
 #define GXB_COMPLEX_H
 
-    #if defined ( __cplusplus )
-
-        extern "C++"
-        {
-            // C++ complex types
-            #include <cmath>
-            #include <complex>
-            #undef I
-            typedef std::complex<float>  GxB_FC32_t ;
-            typedef std::complex<double> GxB_FC64_t ;
-        }
-        #define GxB_CMPLXF(r,i) GxB_FC32_t(r,i)
-        #define GxB_CMPLX(r,i)  GxB_FC64_t(r,i)
-        #define GB_HAS_CMPLX_MACROS 1
-
-    #elif defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
+    #if defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
 
         // Microsoft Windows complex types for C
         #include <complex.h>
@@ -172,8 +154,8 @@
         // ANSI C11 complex types
         #include <complex.h>
         #undef I
-        typedef float  complex GxB_FC32_t ;
-        typedef double complex GxB_FC64_t ;
+        typedef float  _Complex GxB_FC32_t ;
+        typedef double _Complex GxB_FC64_t ;
         #if (defined (CMPLX) && defined (CMPLXF))
             // use the ANSI C11 CMPLX and CMPLXF macros
             #define GxB_CMPLX(r,i) CMPLX (r,i)

--- a/Include/GraphBLAS.h
+++ b/Include/GraphBLAS.h
@@ -135,28 +135,10 @@
 // This is a copy of GraphBLAS/Source/Shared/GxB_complex.h.  It is included
 // here as a full copy so that the GraphBLAS.h file can be self contained.
 
-// See:
-// https://www.drdobbs.com/complex-arithmetic-in-the-intersection-o/184401628#
-
 #ifndef GXB_COMPLEX_H
 #define GXB_COMPLEX_H
 
-    #if defined ( __cplusplus )
-
-        extern "C++"
-        {
-            // C++ complex types
-            #include <cmath>
-            #include <complex>
-            #undef I
-            typedef std::complex<float>  GxB_FC32_t ;
-            typedef std::complex<double> GxB_FC64_t ;
-        }
-        #define GxB_CMPLXF(r,i) GxB_FC32_t(r,i)
-        #define GxB_CMPLX(r,i)  GxB_FC64_t(r,i)
-        #define GB_HAS_CMPLX_MACROS 1
-
-    #elif defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
+    #if defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
 
         // Microsoft Windows complex types for C
         #include <complex.h>
@@ -172,8 +154,8 @@
         // ANSI C11 complex types
         #include <complex.h>
         #undef I
-        typedef float  complex GxB_FC32_t ;
-        typedef double complex GxB_FC64_t ;
+        typedef float  _Complex GxB_FC32_t ;
+        typedef double _Complex GxB_FC64_t ;
         #if (defined (CMPLX) && defined (CMPLXF))
             // use the ANSI C11 CMPLX and CMPLXF macros
             #define GxB_CMPLX(r,i) CMPLX (r,i)

--- a/Source/Shared/GxB_complex.h
+++ b/Source/Shared/GxB_complex.h
@@ -17,22 +17,7 @@
 #ifndef GXB_COMPLEX_H
 #define GXB_COMPLEX_H
 
-    #if defined ( __cplusplus )
-
-        extern "C++"
-        {
-            // C++ complex types
-            #include <cmath>
-            #include <complex>
-            #undef I
-            typedef std::complex<float>  GxB_FC32_t ;
-            typedef std::complex<double> GxB_FC64_t ;
-        }
-        #define GxB_CMPLXF(r,i) GxB_FC32_t(r,i)
-        #define GxB_CMPLX(r,i)  GxB_FC64_t(r,i)
-        #define GB_HAS_CMPLX_MACROS 1
-
-    #elif ( _MSC_VER && !(__INTEL_COMPILER || __INTEL_CLANG_COMPILER) )
+    #if ( _MSC_VER && !(__INTEL_COMPILER || __INTEL_CLANG_COMPILER) )
 
         // Microsoft Windows complex types for C
         #include <complex.h>
@@ -48,8 +33,8 @@
         // ANSI C11 complex types
         #include <complex.h>
         #undef I
-        typedef float  complex GxB_FC32_t ;
-        typedef double complex GxB_FC64_t ;
+        typedef float  _Complex GxB_FC32_t ;
+        typedef double _Complex GxB_FC64_t ;
         #if (defined (CMPLX) && defined (CMPLXF))
             // use the ANSI C11 CMPLX and CMPLXF macros
             #define GxB_CMPLX(r,i) CMPLX (r,i)


### PR DESCRIPTION
Don't use type for complex arguments in function declarations in the header
that differs from the type that was used when the library was built.

This is similar to https://github.com/DrTimothyAldenDavis/SuiteSparse/pull/312