### PR TITLE
Fixing bugs + nits in apply, rowscale, colscale CUDA kernels

### DIFF
--- a/CUDA/GB_cuda_apply_bind1st_jit.cpp
+++ b/CUDA/GB_cuda_apply_bind1st_jit.cpp
@@ -41,11 +41,8 @@ GrB_Info GB_cuda_apply_bind1st_jit
         hash, &encoding, suffix, NULL, NULL,
         (GB_Operator) op, ctype, NULL, A->type) ;
     if (info != GrB_SUCCESS) {
-        printf ("oopsies\n") ;
         return (info) ;
     }
-    
-    printf ("did pass here in bind1st_jit\n") ;
 
     //--------------------------------------------------------------------------
     // call the jit kernel and return result

--- a/CUDA/GB_cuda_apply_bind2nd_jit.cpp
+++ b/CUDA/GB_cuda_apply_bind2nd_jit.cpp
@@ -41,10 +41,8 @@ GrB_Info GB_cuda_apply_bind2nd_jit
         hash, &encoding, suffix, NULL, NULL,
         (GB_Operator) op, ctype, A->type, NULL) ;
     if (info != GrB_SUCCESS){ 
-        printf ("oopsies\n") ;
         return (info) ;
     }
-    printf ("passed here in bind2nd jit\n") ;
 
     //--------------------------------------------------------------------------
     // call the jit kernel and return result

--- a/CUDA/JitKernels/GB_jit_kernel_cuda_apply_bind1st.cu
+++ b/CUDA/JitKernels/GB_jit_kernel_cuda_apply_bind1st.cu
@@ -11,8 +11,10 @@ __global__ void GB_cuda_apply_bind1st_kernel
     const GB_B_TYPE *__restrict__ Bx = (GB_B_TYPE *) B->x ;
     GB_C_TYPE *__restrict__ Cx = (GB_C_TYPE *) Cx_out ;
 
+    #if ( GB_B_IS_BITMAP )
     const int8_t *__restrict__ Bb = B->b ;
-
+    #endif
+    
     GB_B_NHELD (nvals) ;
 
     int tid = blockDim.x * blockIdx.x + threadIdx.x;

--- a/CUDA/JitKernels/GB_jit_kernel_cuda_apply_bind2nd.cu
+++ b/CUDA/JitKernels/GB_jit_kernel_cuda_apply_bind2nd.cu
@@ -7,12 +7,14 @@ __global__ void GB_cuda_apply_bind2nd_kernel
     const GB_void *scalarx
 )
 {
-    const GB_X_TYPE x = * ((GB_X_TYPE *) scalarx) ; // gets scalarx [0]
+    const GB_Y_TYPE x = * ((GB_Y_TYPE *) scalarx) ; // gets scalarx [0]
     const GB_A_TYPE *__restrict__ Ax = (GB_A_TYPE *) A->x ;
     GB_C_TYPE *__restrict__ Cx = (GB_C_TYPE *) Cx_out ;
 
+    #if ( GB_A_IS_BITMAP )
     const int8_t *__restrict__ Ab = A->b ;
-
+    #endif
+    
     GB_A_NHELD (nvals) ;
 
     int tid = blockDim.x * blockIdx.x + threadIdx.x;

--- a/CUDA/JitKernels/GB_jit_kernel_cuda_rowscale.cu
+++ b/CUDA/JitKernels/GB_jit_kernel_cuda_rowscale.cu
@@ -15,10 +15,19 @@ __global__ void GB_cuda_rowscale_kernel
     #define D_iso GB_A_ISO
     #define B_iso GB_B_ISO
 
+    #if ( GB_B_IS_SPARSE || GB_B_IS_HYPER )
     const int64_t *__restrict__ Bi = B->i ;
+    #endif
+
+    #if ( GB_B_IS_BITMAP )
     const int8_t *__restrict__ Bb = B->b ;
+    #endif
+
     GB_B_NHELD (bnz) ;
+
+    #if ( GB_A_IS_BITMAP || GB_A_IS_FULL )
     const int64_t bvlen = B->vlen ;
+    #endif
 
     int ntasks = gridDim.x * blockDim.x;
     int tid = blockIdx.x * blockDim.x + threadIdx.x;

--- a/Source/GB_colscale.c
+++ b/Source/GB_colscale.c
@@ -234,6 +234,7 @@ GrB_Info GB_colscale                // C = A*D, column scale with diagonal D
 
         #ifndef GBCOMPACT
         GB_IF_FACTORY_KERNELS_ENABLED
+        if (info == GrB_NO_VALUE)
         { 
 
             //------------------------------------------------------------------

--- a/Source/GB_rowscale.c
+++ b/Source/GB_rowscale.c
@@ -216,35 +216,34 @@ GrB_Info GB_rowscale                // C = D*B, row scale with diagonal D
 
         #ifndef GBCOMPACT
         GB_IF_FACTORY_KERNELS_ENABLED
-        if (info == GrB_NO_VALUE){
+        if (info == GrB_NO_VALUE)
+        { 
+
+            //------------------------------------------------------------------
+            // define the worker for the switch factory
+            //------------------------------------------------------------------
+
+            #define GB_DxB(mult,xname) GB (_DxB_ ## mult ## xname)
+
+            #define GB_BINOP_WORKER(mult,xname)                     \
+            {                                                       \
+                info = GB_DxB(mult,xname) (C, D, B, nthreads) ;     \
+            }                                                       \
+            break ;
+
+            //------------------------------------------------------------------
+            // launch the switch factory
+            //------------------------------------------------------------------
+
+            GB_Type_code xcode, ycode, zcode ;
+            if (GB_binop_builtin (D->type, D_is_pattern, B->type, B_is_pattern,
+                mult, flipxy, &opcode, &xcode, &ycode, &zcode))
             { 
-
-                //------------------------------------------------------------------
-                // define the worker for the switch factory
-                //------------------------------------------------------------------
-
-                #define GB_DxB(mult,xname) GB (_DxB_ ## mult ## xname)
-
-                #define GB_BINOP_WORKER(mult,xname)                     \
-                {                                                       \
-                    info = GB_DxB(mult,xname) (C, D, B, nthreads) ;     \
-                }                                                       \
-                break ;
-
-                //------------------------------------------------------------------
-                // launch the switch factory
-                //------------------------------------------------------------------
-
-                GB_Type_code xcode, ycode, zcode ;
-                if (GB_binop_builtin (D->type, D_is_pattern, B->type, B_is_pattern,
-                    mult, flipxy, &opcode, &xcode, &ycode, &zcode))
-                { 
-                    // C=D*B, rowscale with built-in operator
-                    #define GB_BINOP_IS_SEMIRING_MULTIPLIER
-                    #define GB_NO_PAIR
-                    #include "GB_binop_factory.c"
-                    #undef  GB_BINOP_IS_SEMIRING_MULTIPLIER
-                }
+                // C=D*B, rowscale with built-in operator
+                #define GB_BINOP_IS_SEMIRING_MULTIPLIER
+                #define GB_NO_PAIR
+                #include "GB_binop_factory.c"
+                #undef  GB_BINOP_IS_SEMIRING_MULTIPLIER
             }
         }
         #endif

--- a/Source/Template/GB_jit_kernel_proto.h
+++ b/Source/Template/GB_jit_kernel_proto.h
@@ -588,7 +588,7 @@ GrB_Info GB_jit_kernel_colscale                                         \
 (                                                                       \
     GrB_Matrix C,                                                       \
     GrB_Matrix A,                                                       \
-    GrB_Matrix B,                                                       \
+    GrB_Matrix D,                                                       \
     cudaStream_t stream,                                                \
     int32_t gridsz,                                                     \
     int32_t blocksz                                                     \


### PR DESCRIPTION
Changes to `Source/GB_colscale.c`:
* Add `info == GrB_NO_VALUE` check for factory kernel after calling CUDA jit

Changes to `Source/GB_rowscale.c`:
* Fixed a nit

Changes to `CUDA/JitKernels/GB_cuda_apply_bind1st_jit.cpp` and `CUDA/JitKernels/GB_cuda_apply_bind2nd_jit.cpp`:
* Removing debug statements

Changes to `CUDA/JitKernels/GB_jit_kernel_cuda_colscale.cu`:
* Fixed typo with GrB_Matrix; was misspelled as "GrB_Matirx"
* Fixed use of incorrect variable name

Changes to `Source/Template/GB_jit_kernel_proto.h`:
* Fixed naming of matrices in prototype of CUDA colscale kernel

Changes to all `apply`, `rowscale`, and `colscale` kernels in `CUDA/JitKernels`:
* Eliminating unnecessary JIT compiler warnings
