### PR TITLE
CUDA select_sparse near-complete

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif ( )
 
 # CUDA is under development for now, and not deployed in production:
 # set ( GRAPHBLAS_USE_CUDA OFF )
-  set ( GRAPHBLAS_USE_CUDA ON )     # use this for CUDA development only
+set ( GRAPHBLAS_USE_CUDA ON )     # use this for CUDA development only
 
 include ( SuiteSparsePolicy )
 

--- a/CUDA/GB_cuda_select.hpp
+++ b/CUDA/GB_cuda_select.hpp
@@ -11,6 +11,31 @@
 
 #include "GB_cuda.hpp"
 
+//------------------------------------------------------------------------------
+// GB_select_iso: assign the iso value of C for GB_*selector
+//------------------------------------------------------------------------------
+
+static inline void GB_select_iso
+(
+    GB_void *Cx,                    // output iso value (same type as A)
+    const GB_Opcode opcode,         // selector opcode
+    const GB_void *athunk,          // thunk scalar, of size asize
+    const GB_void *Ax,              // Ax [0] scalar, of size asize
+    const size_t asize
+)
+{
+    if (opcode == GB_VALUEEQ_idxunop_code)
+    { 
+        // all entries in C are equal to thunk
+        memcpy (Cx, athunk, asize) ;
+    }
+    else
+    { 
+        // A and C are both iso
+        memcpy (Cx, Ax, asize) ;
+    }
+}
+
 GrB_Info GB_cuda_select_bitmap_jit
 (
     // output:
@@ -34,10 +59,10 @@ GrB_Info GB_cuda_select_sparse_jit
     GrB_Matrix C,
     // input:
     const bool C_iso,
-    const GrB_IndexUnaryOp op,
-    const bool flipij,
     const GrB_Matrix A,
+    const bool flipij,
     const GB_void *ythunk,
+    const GrB_IndexUnaryOp op,
     // CUDA stream and launch parameters:
     cudaStream_t stream,
     int32_t gridsz,

--- a/CUDA/GB_cuda_select_sparse.cpp
+++ b/CUDA/GB_cuda_select_sparse.cpp
@@ -7,7 +7,10 @@
 }
 
 #undef GB_FREE_ALL
-#define GB_FREE_ALL ;
+#define GB_FREE_ALL         \
+{                           \
+    GB_phybix_free (C) ;    \
+}
 
 #define BLOCK_SIZE 512
 #define LOG2_BLOCK_SIZE 9
@@ -22,15 +25,11 @@ GrB_Info GB_cuda_select_sparse
     const GB_void *ythunk
 )
 {
-    // in progress
-    return (GrB_NOT_IMPLEMENTED) ;
-
-#if 0
-
     // check inputs
     ASSERT (C != NULL && !(C->static_header)) ;
     ASSERT (A != NULL && !(A->static_header)) ;
 
+    GrB_Info info = GrB_NO_VALUE ;
     GB_void *ythunk_cuda = NULL ;
     size_t ythunk_cuda_size = 0 ;
     if (ythunk != NULL && op != NULL && op->ytype != NULL)
@@ -56,17 +55,41 @@ GrB_Info GB_cuda_select_sparse
     int64_t raw_gridsz = GB_ICEIL (anz, BLOCK_SIZE) ;
     int32_t gridsz = std::min (raw_gridsz, (int64_t) (number_of_sms * 256)) ;
 
-    GrB_Info info = GrB_NO_VALUE ;
+    // Initialize C to be a user-returnable hypersparse empty matrix.
+    // If needed, we handle the hyper->sparse conversion below.
+    GB_OK (GB_new (&C, A->type, A->vlen, A->vdim, GB_Ap_calloc, true,
+            GxB_HYPERSPARSE, A->hyper_switch, 1)) ;
+    C->jumbled = A->jumbled ;
+    C->iso = C_iso ;
 
     info = GB_cuda_select_sparse_jit (C, C_iso, A,
         flipij, ythunk_cuda, op, stream, gridsz, BLOCK_SIZE) ;
-    if (info == GrB_NO_VALUE) info = GrB_PANIC ;
-    GB_OK (info) ;
 
     CUDA_OK (cudaStreamSynchronize (stream)) ;
     CUDA_OK (cudaStreamDestroy (stream)) ;
 
+    // if (info == GrB_NO_VALUE) info = GrB_PANIC ; // see GxB_JIT_ERROR
+    GB_OK (info) ;
+
+    if (A->h == NULL) {
+        // The result should be sparse, but the result is hypersparse.
+        // Perform the hyper->sparse conversion.
+        ASSERT (GB_IS_HYPERSPARSE (C)) ;
+        GB_OK (GB_convert_hyper_to_sparse (C, false)) ;
+    }
+
+    if (C->nvals == 0) {
+        // The result is empty, nothing more to do.
+        GB_FREE_WORKSPACE ;
+        return info ;
+    } else {
+        if (C_iso) {
+            // If C is iso, initialize the iso entry
+            GB_select_iso ((GB_void *) C->x, op->opcode, ythunk,
+                (GB_void *) A->x, op->ytype->size) ;
+        }
+    }
+
     GB_FREE_WORKSPACE ;
     return info ;
-#endif
 }

--- a/CUDA/GB_cuda_select_sparse.cpp
+++ b/CUDA/GB_cuda_select_sparse.cpp
@@ -54,6 +54,7 @@ GrB_Info GB_cuda_select_sparse
     int32_t number_of_sms = GB_Global_gpu_sm_get (0) ;
     int64_t raw_gridsz = GB_ICEIL (anz, BLOCK_SIZE) ;
     int32_t gridsz = std::min (raw_gridsz, (int64_t) (number_of_sms * 256)) ;
+    gridsz = std::max (gridsz, 1) ;
 
     // Initialize C to be a user-returnable hypersparse empty matrix.
     // If needed, we handle the hyper->sparse conversion below.

--- a/CUDA/GB_cuda_select_sparse_jit.cpp
+++ b/CUDA/GB_cuda_select_sparse_jit.cpp
@@ -20,12 +20,7 @@ GrB_Info GB_cuda_select_sparse_jit
     int32_t gridsz,
     int32_t blocksz
 )
-{ 
-    // in progress
-    return (GrB_NO_VALUE) ;
-
-#if 0
-
+{
     //--------------------------------------------------------------------------
     // encodify the problem
     //--------------------------------------------------------------------------
@@ -51,6 +46,5 @@ GrB_Info GB_cuda_select_sparse_jit
     //--------------------------------------------------------------------------
 
     GB_jit_dl_function GB_jit_kernel = (GB_jit_dl_function) dl_function ;
-    return (GB_jit_kernel (C, A, ythunk, stream, gridsz, blocksz)) ;
-#endif
+    return (GB_jit_kernel (C, A, ythunk, stream, gridsz, blocksz, &GB_callback)) ;
 }

--- a/CUDA/include/GB_cuda_kernel.cuh
+++ b/CUDA/include/GB_cuda_kernel.cuh
@@ -73,6 +73,7 @@ extern "C"
     #include "include/GB_saxpy3task_struct.h"
     #include "include/GB_callback.h"
     #include "include/GB_hyper_hash_lookup.h"
+    #include "include/GB_ok.h"
 }
 
 #include "GB_cuda_error.hpp"

--- a/CUDA/template/GB_cuda_cumsum.cuh
+++ b/CUDA/template/GB_cuda_cumsum.cuh
@@ -10,7 +10,12 @@
 #ifndef GB_CUDA_CUMSUM
 #define GB_CUDA_CUMSUM
 
-#include <cub/cub.h>
+#include <cub/cub.cuh>
+
+#define GB_FREE_ALL             \
+{                               \
+    cudaFree (d_temp_storage) ; \
+}
 
 typedef enum GB_cuda_cumsum_type
 {
@@ -20,8 +25,8 @@ typedef enum GB_cuda_cumsum_type
 
 __host__ GrB_Info GB_cuda_cumsum             // compute the cumulative sum of an array
 (
-    int64_t *restrict in,    // size n or n+1, input
-    int64_t *restrict out,   // size n or n+1, output.
+    int64_t *__restrict__ out,   // size n or n+1, output.
+    int64_t *__restrict__ in,    // size n or n+1, input
     // to do an in-place cumsum, pass out == in
 
     const int64_t n,
@@ -44,26 +49,25 @@ __host__ GrB_Info GB_cuda_cumsum             // compute the cumulative sum of an
     switch (type)
     {
         case GB_CUDA_CUMSUM_INCLUSIVE:
-            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
+            cub::DeviceScan::InclusiveSum (d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
             break;
         default:
-            cub::DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
+            cub::DeviceScan::ExclusiveSum (d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
     }
 
-    CUDA_OK (cudaMalloc(&d_temp_storage, temp_storage_bytes)) ;
+    CUDA_OK (cudaMalloc (&d_temp_storage, temp_storage_bytes)) ;
 
     // Run
     switch (type)
     {
         case GB_CUDA_CUMSUM_INCLUSIVE:
-            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
+            cub::DeviceScan::InclusiveSum (d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
             break;
         default:
-            cub::DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
+            cub::DeviceScan::ExclusiveSum (d_temp_storage, temp_storage_bytes, in, out, n, stream) ;
     }
-
-    CUDA_OK (cudaFree(d_temp_storage)) ;
-
+    cudaFree (d_temp_storage) ;
+    
     return GrB_SUCCESS;
 }
 #endif

--- a/Source/select/GB_selector.c
+++ b/Source/select/GB_selector.c
@@ -23,8 +23,6 @@
 
 #define GB_FREE_ALL ;
 
-static int run = 0;
-
 GrB_Info GB_selector
 (
     GrB_Matrix C,               // output matrix, NULL or existing header
@@ -163,12 +161,6 @@ GrB_Info GB_selector
     info = GrB_NO_VALUE ;
 
     // FIXME: pass in a T matrix, below, not C
-    struct GB_Matrix_opaque T_header ;
-    GrB_Matrix T ;
-    GB_CLEAR_STATIC_HEADER (T, &T_header) ;
-
-    bool compare = false ;
-
     #if defined ( GRAPHBLAS_HAS_CUDA )
     if (!in_place_A /* FIXME: Workaround for CUDA kernel not
         handling in-place condition. Fix by building result
@@ -180,71 +172,16 @@ GrB_Info GB_selector
         in this case, so make this go to the CPU. */
         && GB_cuda_select_branch (A, op))
     {
-        compare = true ;
-        info = GB_cuda_select_sparse (T, C_iso, op, flipij, A, ythunk) ;
+
+        info = GB_cuda_select_sparse (C, C_iso, op, flipij, A, ythunk) ;
     }
     #endif
-    // Failing on TriangleCount, Cached_NDiag
-    if (/* info == GrB_NO_VALUE */ true)
-    {
-        run++;
-        bool fallout = false;
-        #define SAME(a, b, fmt, args...)                                            \
-        {                                                                           \
-            if (fallout) {                                                          \
-                printf (fmt, args);                                                 \
-                printf ("\n");                                                      \
-            }                                                                       \
-            else if (a != b) {                                                      \
-                fallout = true;                                                     \
-                printf ("======== [VIDITH]: Hit on run: %d ========\n", run);       \
-                printf (fmt, args) ;                                                \
-                printf ("\n") ;                                                     \
-                printf ("Jumbled? %d\n", A->jumbled) ;                              \
-                printf ("Dumping [Ax, Ai]\n") ;                                     \
-                int pi = 0;                                                         \
-                int pval = A->p[pi];                                                \
-                for (int i = 0; i < A->nvals; i++) {                                \
-                    if (i == pval) {                                                \
-                        printf ("== COL %d ==\n", pi);                              \
-                        pi++;                                                       \
-                        pval = A->p[pi];                                            \
-                    }                                                               \
-                    printf ("(%d): Ax: %0.5f; Ai: %ld\n", i,                        \
-                        ((double*) A->x)[i], A->i[i]) ;                             \
-                }                                                                   \
-                printf ("Dumping Ap\n") ;                                           \
-                for (int i = 0; i < A->plen + 1; i++) {                             \
-                    printf ("(%d): Ap: %ld\n", i, A->p[i]) ;                        \
-                }                                                                   \
-                printf ("Ah exists? %d\n", (A->h != NULL)) ;                        \
-                if (A->h != NULL) {                                                 \
-                    printf ("Dumping Ah\n") ;                                       \
-                    for (int i = 0; i < A->plen; i++) {                             \
-                        printf ("(%d): Ah: %ld\n", i, A->h[i]) ;                    \
-                    }                                                               \
-                }                                                                   \
-                printf ("Op is: %d\n", op->opcode) ;                                \
-                printf ("Thunk is: %0.3f\n", *((double*) Thunk->x));                \
-                printf ("======== [VIDITH]: Done ========\n") ;                     \
-            }                                                                       \
-        }
 
+    if (info == GrB_NO_VALUE)
+    {
         // FIXME: Extract in-place handling out of this function
         info = GB_select_sparse (C, C_iso, op, flipij, A, ithunk, athunk,
             ythunk, Werk) ;
-        
-        if (compare) {
-            // SAME (C->plen, T->plen, "hit plens: cpu: %ld, gpu: %ld", C->plen, T->plen) ;
-            SAME (C->vlen, T->vlen, "hit vlen: cpu: %ld, gpu: %ld", C->vlen, T->vlen) ;
-            SAME (C->vdim, T->vdim, "hit vdim: cpu: %ld, gpu: %ld", C->vdim, T->vdim) ;
-            SAME (C->nvec, T->nvec, "hit nvec: cpu: %ld, gpu: %ld", C->nvec, T->nvec) ;
-            SAME (C->nvec_nonempty, T->nvec_nonempty, "hit nvec_nonempty: cpu: %ld, gpu: %ld", C->nvec_nonempty, T->nvec_nonempty) ;
-            SAME (C->nvals, T->nvals, "hit nvals: cpu: %ld, gpu: %ld", C->nvals, T->nvals) ;
-            if (fallout) {
-                exit(-1);
-            }
-        }
     }
  
     // FIXME: handle in_place_A case here, not in select_sparse:


### PR DESCRIPTION
CUDA select_sparse passes all LAGraph tests on the latest (Nov 21) version of the `v1.2` branch**, along with the GraphBLAS demos. In total, the LAGraph tests compile 58 variants of the kernel.
Remaining topics to resolve:
1. Handling hyper -> sparse conversion if the output must be sparse. This is currently handled with `GB_convert_hyper_to_sparse()`, which should perform better than the single-threaded hyper-pruning done for the sparse -> hyper conversion on the CPU select_sparse kernel. However, it would be good to have a CUDA implementation of `GB_convert_hyper_to_sparse()`, since otherwise we would be bottlenecked by the host <-> device memory traffic along with the work needed to perform the conversion.
2. Handle the in-place case for CUDA. As discussed offline and in comments in `GB_selector.c`, this should be done by feeding a temp matrix to both the CUDA and CPU select_sparse kernels and then transplanting to either C or A accordingly. I would be willing to work on this as a follow up.

** I noticed on subsequent test runs both on my local system and on Cholesky that the `LG_AllKtruss` test fails sporadically with a CUDA illegal memory access. This is the only LAGraph test that has this issue and its occurrence is unpredictable. I have not been able to consistently reproduce this failure on either my local system or Cholesky. I have tried building GraphBLAS/LAGraph in Debug/Release modes, and switching between `-O3` and `-g` in the nvcc compile flags but the behavior is the same. I tried using `cuda-gdb` to catch the source of the error (with the `-g -G` compile flags), but I wasn't able to hit the error (although I did see another weird issue with the jitifyer not being able to acquire the file lock during the `LG_AllKtruss_errors`test).
The only useful information I was able to gather was that the failure only seems to happen when compiling the kernels for the first time. It's unclear why that would be.