### PR TITLE
Change RISC-V RVV1.0 compile defines

### DIFF
--- a/Source/include/GB_compiler.h
+++ b/Source/include/GB_compiler.h
@@ -336,7 +336,7 @@
 
 // prefix for function with target rvv1.0
 #if GB_COMPILER_SUPPORTS_RVV1
-        #define GB_TARGET_RVV1 __attribute__ ((target ("arch=rv64gcv")))
+        #define GB_TARGET_RVV1 __attribute__ ((target ("arch=+v")))
 #else
     #define GB_TARGET_RVV1
 #endif

--- a/Source/include/GB_compiler.h
+++ b/Source/include/GB_compiler.h
@@ -323,7 +323,7 @@
 #if GBRISCV64
     #if GB_COMPILER_GCC
     // TODO: add other compilers
-        #if __GNUC__ >= 13
+        #if __GNUC__ >= 14
             #define GB_COMPILER_SUPPORTS_RVV1 1
         #else
             #define GB_COMPILER_SUPPORTS_RVV1 0


### PR DESCRIPTION
# Changes for properly risc-v native build

- Changed necessary for RVV1.0 gcc version from 13 to 14 due to some bug that appears while native building that occurres on gcc with version lower than 13 (and clang version lower than 19 I guess) (https://github.com/llvm/llvm-project/issues/56592).
- Set different target arch (previous was redundant). 