### PR TITLE
Add ngpus check to remaining CUDA branches

### DIFF
--- a/CUDA/GB_cuda_apply_binop_branch.cpp
+++ b/CUDA/GB_cuda_apply_binop_branch.cpp
@@ -40,7 +40,11 @@ bool GB_cuda_apply_binop_branch
         ok = ok && GB_cuda_type_branch (op->ztype) ;
     }
 
-    ok = ok && (op->hash != UINT64_MAX) ; 
+    double work = Gb_nnz_held (A) ;
+    int gpu_count = GB_ngpus_to_use (work) ;
+
+    ok = ok && (op->hash != UINT64_MAX) ;
+    ok = ok && (gpu_count > 0);
 
     return (ok) ;
 }

--- a/CUDA/GB_cuda_apply_binop_branch.cpp
+++ b/CUDA/GB_cuda_apply_binop_branch.cpp
@@ -40,7 +40,7 @@ bool GB_cuda_apply_binop_branch
         ok = ok && GB_cuda_type_branch (op->ztype) ;
     }
 
-    double work = Gb_nnz_held (A) ;
+    double work = GB_nnz_held (A) ;
     int gpu_count = GB_ngpus_to_use (work) ;
 
     ok = ok && (op->hash != UINT64_MAX) ;

--- a/CUDA/GB_cuda_apply_unop_branch.cpp
+++ b/CUDA/GB_cuda_apply_unop_branch.cpp
@@ -40,6 +40,9 @@ bool GB_cuda_apply_unop_branch
         ok = ok && (GB_cuda_type_branch (op->ztype)) ;
     }
     
+    double work = GB_nnz_held (A) ;
+    int gpu_count = GB_ngpus_to_use (work) ;
+
     ok = ok && (op->hash != UINT64_MAX) ;
 
     return ok ;

--- a/CUDA/GB_cuda_apply_unop_branch.cpp
+++ b/CUDA/GB_cuda_apply_unop_branch.cpp
@@ -44,6 +44,7 @@ bool GB_cuda_apply_unop_branch
     int gpu_count = GB_ngpus_to_use (work) ;
 
     ok = ok && (op->hash != UINT64_MAX) ;
+    ok = ok && (gpu_count > 0);
 
     return ok ;
 }

--- a/CUDA/GB_cuda_colscale_branch.cpp
+++ b/CUDA/GB_cuda_colscale_branch.cpp
@@ -31,5 +31,9 @@ bool GB_cuda_colscale_branch
     {
         return false;
     }
-    return true;
+
+    double work = GB_nnz_held (A) ;
+    int gpu_count = GB_ngpus_to_use (work) ;
+
+    return (gpu_count > 0);
 }

--- a/CUDA/GB_cuda_rowscale_branch.cpp
+++ b/CUDA/GB_cuda_rowscale_branch.cpp
@@ -31,5 +31,9 @@ bool GB_cuda_rowscale_branch
     {
         return false;
     }
-    return true;
+
+    double work = GB_nnz_held (B) ;
+    int gpu_count = GB_ngpus_to_use (work) ;
+    
+    return (gpu_count > 0);
 }

--- a/CUDA/GB_cuda_select_branch.cpp
+++ b/CUDA/GB_cuda_select_branch.cpp
@@ -40,8 +40,12 @@ bool GB_cuda_select_branch
         ok = ok && (GB_cuda_type_branch (op->ztype)) ;
     }
 
-    ok = ok && (op->hash != UINT64_MAX) ;
+    double work = GB_nnz_held (A) ;
+    int gpu_count = GB_ngpus_to_use (work) ;
 
+    ok = ok && (op->hash != UINT64_MAX) ;
+    ok = ok && (gpu_count > 0);
+    
     return ok ;
 }
 


### PR DESCRIPTION
* Add `GB_ngpus_to_use` check in remaining CUDA branches to ensure the CUDA JIT is not invoked if there are no devices present, which would result in a `GxB_GPU_ERROR`.
