### PR TITLE
Fix building with OpenMP on Windows (in Source/sort/GB_bitonic.c)

### DIFF
--- a/Source/sort/GB_bitonic.c
+++ b/Source/sort/GB_bitonic.c
@@ -35,8 +35,9 @@ GrB_Info GB_bitonic
             // parallel loop for all threads in the threadblock:
 //          for (int64_t ipair = tid ; ipair < Nhalf ; ipair += nthreads)
 
+            int64_t ipair ;
             #pragma omp parallel for num_threads(nthreads) schedule(static)
-            for (int64_t ipair = 0 ; ipair < Nhalf ; ipair++)
+            for (ipair = 0 ; ipair < Nhalf ; ipair++)
             {
                 // Consider the pair of entries A [ileft] and A [iright] where
                 // ileft < iright always holds.  The ileft entry is obtained by


### PR DESCRIPTION
Changes like this have been needed before: https://github.com/DrTimothyAldenDavis/GraphBLAS/issues/91

This is currently causing the build on conda-forge to fail: https://github.com/conda-forge/graphblas-feedstock/pull/83

I also wonder whether these lines should be similarly updated:
https://github.com/DrTimothyAldenDavis/GraphBLAS/blob/2135315ec62aca4f7e4b477c0d96a859386eed92/Source/mxm/template/GB_AxB_saxpy5_lv.c#L40-L41